### PR TITLE
Update version to 1.1.3 and add TurnstileValidationService bean; refa…

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Add the following dependency to your `pom.xml`:
 <dependency>
     <groupId>com.digitalsanctuary</groupId>
     <artifactId>spring-cf-turnstile</artifactId>
-    <version>1.1.2</version>
+    <version>1.1.3</version>
 </dependency>
 ```
 
@@ -46,7 +46,7 @@ Add the following dependency to your `build.gradle`:
 
 ```groovy
 dependencies {
-    implementation 'com.digitalsanctuary:spring-cf-turnstile:1.1.2'
+    implementation 'com.digitalsanctuary:spring-cf-turnstile:1.1.3'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ import com.vanniktech.maven.publish.JavaLibrary
 import com.vanniktech.maven.publish.JavadocJar
 
 group 'com.digitalsanctuary.cf.turnstile'
-version '1.1.2'
+version '1.1.3'
 description = 'SpringBoot Cloudflare Turnstile Library'
 
 ext {

--- a/src/main/java/com/digitalsanctuary/cf/turnstile/TurnstileConfiguration.java
+++ b/src/main/java/com/digitalsanctuary/cf/turnstile/TurnstileConfiguration.java
@@ -28,6 +28,11 @@ public class TurnstileConfiguration {
         return builder.build();
     }
 
+    @Bean
+    public TurnstileValidationService turnstileValidationService() {
+        return new TurnstileValidationService(turnstileRestTemplate(new RestTemplateBuilder()));
+    }
+
     /**
      * Method executed after the bean initialization.
      * <p>

--- a/src/test/java/com/digitalsanctuary/cf/test/TestApplication.java
+++ b/src/test/java/com/digitalsanctuary/cf/test/TestApplication.java
@@ -1,4 +1,4 @@
-package com.digitalsanctuary.cf;
+package com.digitalsanctuary.cf.test;
 
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import lombok.extern.slf4j.Slf4j;

--- a/src/test/java/com/digitalsanctuary/cf/test/turnstile/TurnstileValidationServiceTest.java
+++ b/src/test/java/com/digitalsanctuary/cf/test/turnstile/TurnstileValidationServiceTest.java
@@ -1,11 +1,12 @@
-package com.digitalsanctuary.cf.turnstile;
+package com.digitalsanctuary.cf.test.turnstile;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import com.digitalsanctuary.cf.TestApplication;
+import com.digitalsanctuary.cf.test.TestApplication;
+import com.digitalsanctuary.cf.turnstile.TurnstileValidationService;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j


### PR DESCRIPTION
This pull request includes updates to dependencies, the addition of a new service bean, and renaming of test files for better organization. The most important changes include updating dependency versions, adding a new service bean, and renaming test files.

Library Version updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L39-R39): Updated the version of `spring-cf-turnstile` dependency from `1.1.2` to `1.1.3` in both `pom.xml` and `build.gradle` examples. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L39-R39) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L49-R49)

New service bean:

* [`src/main/java/com/digitalsanctuary/cf/turnstile/TurnstileConfiguration.java`](diffhunk://#diff-7e20481818aaae4cc71056492600071f40786651a22b2dadf4bb979364d2c062R31-R35): Added a new `TurnstileValidationService` bean.

Test package changes to better detect issues:

* [`src/test/java/com/digitalsanctuary/cf/test/TestApplication.java`](diffhunk://#diff-f16a43eff373f25ea2653ba9c8ab61ebe25d6cea4173179c5253d30da9c3748cL1-R1): Renamed from `src/test/java/com/digitalsanctuary/cf/TestApplication.java` and updated the package name accordingly.
* [`src/test/java/com/digitalsanctuary/cf/test/turnstile/TurnstileValidationServiceTest.java`](diffhunk://#diff-50452082e54a32ece461be5b7dfc27055a8fbbcfe53375c6e0a9665715798b5eL1-R9): Renamed from `src/test/java/com/digitalsanctuary/cf/turnstile/TurnstileValidationServiceTest.java` and updated the package name accordingly.