### PR TITLE
Update project name and version to 1.1.4 in README, build.gradle, and…

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Add the following dependency to your `pom.xml`:
 ```xml
 <dependency>
     <groupId>com.digitalsanctuary</groupId>
-    <artifactId>spring-cf-turnstile</artifactId>
-    <version>1.1.3</version>
+    <artifactId>ds-spring-cf-turnstile</artifactId>
+    <version>1.1.4</version>
 </dependency>
 ```
 
@@ -46,7 +46,7 @@ Add the following dependency to your `build.gradle`:
 
 ```groovy
 dependencies {
-    implementation 'com.digitalsanctuary:spring-cf-turnstile:1.1.3'
+    implementation 'com.digitalsanctuary:ds-spring-cf-turnstile:1.1.4'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ import com.vanniktech.maven.publish.JavaLibrary
 import com.vanniktech.maven.publish.JavadocJar
 
 group 'com.digitalsanctuary.cf.turnstile'
-version '1.1.3'
+version '1.1.4'
 description = 'SpringBoot Cloudflare Turnstile Library'
 
 ext {
@@ -59,7 +59,7 @@ tasks.named('bootJar') {
 
 tasks.named('jar') {
     enabled = true
-    archiveBaseName.set('spring-cf-turnstile')
+    archiveBaseName.set('ds-spring-cf-turnstile')
     archiveClassifier.set('')
 }
 
@@ -103,7 +103,7 @@ mavenPublishing {
   configure(new JavaLibrary(new JavadocJar.Javadoc(), true))
   publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
   signAllPublications()
-  coordinates("com.digitalsanctuary", "spring-cf-turnstile", project.version)
+  coordinates("com.digitalsanctuary", "ds-spring-cf-turnstile", project.version)
 
   pom {
     name = "Spring Cloudflare Turnstile Library"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'spring-cf-turnstile'
+rootProject.name = 'ds-spring-cf-turnstile'


### PR DESCRIPTION
This pull request includes updates to the project dependencies and settings to reflect a new artifact ID and version. The most important changes include updating the dependency information in `README.md` and renaming the root project in `settings.gradle`.

Dependency updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L38-R39): Updated the Maven dependency artifact ID to `ds-spring-cf-turnstile` and version to `1.1.4`.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L49-R49): Updated the Gradle dependency artifact ID to `ds-spring-cf-turnstile` and version to `1.1.4`.

Project settings:

* [`settings.gradle`](diffhunk://#diff-7f825392aa37acd1cee0c2e7b9bb7366ad6eac64f3e6cdd816e156bcb69d30deL1-R1): Renamed the root project to `ds-spring-cf-turnstile`.