### PR TITLE
Implement input validation for Turnstile tokens

### DIFF
--- a/src/test/java/com/digitalsanctuary/cf/test/turnstile/TurnstileValidationServiceTest.java
+++ b/src/test/java/com/digitalsanctuary/cf/test/turnstile/TurnstileValidationServiceTest.java
@@ -19,8 +19,28 @@ public class TurnstileValidationServiceTest {
 
     @Test
     public void testValidateTurnstileResponse_Success() {
-
-        boolean response = turnstileValidationService.validateTurnstileResponse("testToken", "127.0.0.1");
+        // Create a token that will pass our basic validation (length >= 20)
+        String validLengthToken = "0123456789012345678901234567890123456789";
+        
+        boolean response = turnstileValidationService.validateTurnstileResponse(validLengthToken, "127.0.0.1");
         assertTrue(response);
+    }
+    
+    @Test
+    public void testValidateTurnstileResponse_NullToken() {
+        boolean response = turnstileValidationService.validateTurnstileResponse(null, "127.0.0.1");
+        assertTrue(!response); // Should fail with null token
+    }
+    
+    @Test
+    public void testValidateTurnstileResponse_EmptyToken() {
+        boolean response = turnstileValidationService.validateTurnstileResponse("", "127.0.0.1");
+        assertTrue(!response); // Should fail with empty token
+    }
+    
+    @Test
+    public void testValidateTurnstileResponse_ShortToken() {
+        boolean response = turnstileValidationService.validateTurnstileResponse("12345", "127.0.0.1");
+        assertTrue(!response); // Should fail with token that's too short
     }
 }


### PR DESCRIPTION
## Summary
- Added validation for null, empty, and short tokens
- Added validation for blank/empty remote IP addresses
- Added validation for required configuration properties (secret key, URL)
- Added convenience method without remote IP parameter
- Updated tests to verify validation logic works correctly

## Test plan
- Added new test cases specifically for validation scenarios:
  - Null token test
  - Empty token test
  - Short token test
- Verified all tests pass with both JDK 17 and 21
- Full build passes

Fixes #31