### PR TITLE
Add caching for token validation results

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,25 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "java",
+            "name": "Debug Spring Test (Gradle Paths)",
+            "request": "launch",
+            "mainClass": "${file}",
+            "projectName": "SpringCFTurnstile",
+            "classPaths": [
+                "${workspaceFolder}/build/classes/java/main",
+                "${workspaceFolder}/build/classes/java/test",
+                "${workspaceFolder}/build/resources/main",
+                "${workspaceFolder}/build/resources/test"
+            ],
+            "vmArgs": [
+                "-ea",
+                "-Dspring.profiles.active=test"
+            ]
+        }
+    ]
+}

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,10 @@ repositories {
 dependencies {
     // Spring Boot dependencies
     compileOnly "org.springframework.boot:spring-boot-starter-web:$springBootVersion"
+    compileOnly "org.springframework.boot:spring-boot-starter-cache:$springBootVersion"
+
+    // Caffeine cache - efficient in-memory caching
+    compileOnly "com.github.ben-manes.caffeine:caffeine:3.1.8"
 
     // Lombok dependencies
     compileOnly "org.projectlombok:lombok:$lombokVersion"
@@ -46,8 +50,11 @@ dependencies {
 
     // Testing dependencies
     testImplementation "org.springframework.boot:spring-boot-starter-web:$springBootVersion"
+    testImplementation "org.springframework.boot:spring-boot-starter-cache:$springBootVersion"
+    testImplementation "com.github.ben-manes.caffeine:caffeine:3.1.8"
     testImplementation "org.springframework.boot:spring-boot-starter-test:$springBootVersion"
     testImplementation "org.springframework.boot:spring-boot-starter-actuator:$springBootVersion"
+    testImplementation 'org.junit.platform:junit-platform-console:1.9.3'
 }
 
 test {

--- a/src/main/java/com/digitalsanctuary/cf/turnstile/TurnstileConfiguration.java
+++ b/src/main/java/com/digitalsanctuary/cf/turnstile/TurnstileConfiguration.java
@@ -3,8 +3,12 @@ package com.digitalsanctuary.cf.turnstile;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+
+import com.digitalsanctuary.cf.turnstile.config.TurnstileCacheConfig;
+import com.digitalsanctuary.cf.turnstile.config.TurnstileCacheProperties;
 import com.digitalsanctuary.cf.turnstile.config.TurnstileConfigProperties;
 import com.digitalsanctuary.cf.turnstile.config.TurnstileServiceConfig;
+
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 
@@ -26,6 +30,11 @@ import lombok.extern.slf4j.Slf4j;
  *       sitekey: your-turnstile-site-key
  *       secret: your-turnstile-secret-key
  *       url: https://challenges.cloudflare.com/turnstile/v0/siteverify
+ *       cache:
+ *         enabled: true
+ *         ttlSeconds: 300
+ *         maxSize: 1000
+ *         cacheSuccessOnly: true
  * </pre>
  * <p>
  * The {@link #onStartup()} method is annotated with {@link jakarta.annotation.PostConstruct} and is executed 
@@ -34,12 +43,19 @@ import lombok.extern.slf4j.Slf4j;
  * 
  * @see com.digitalsanctuary.cf.turnstile.config.TurnstileConfigProperties
  * @see com.digitalsanctuary.cf.turnstile.config.TurnstileServiceConfig
+ * @see com.digitalsanctuary.cf.turnstile.config.TurnstileCacheProperties
+ * @see com.digitalsanctuary.cf.turnstile.config.TurnstileCacheConfig
  * @see com.digitalsanctuary.cf.turnstile.service.TurnstileValidationService
  */
 @Slf4j
 @Configuration
 @AutoConfiguration
-@Import({TurnstileServiceConfig.class, TurnstileConfigProperties.class})
+@Import({
+    TurnstileServiceConfig.class, 
+    TurnstileConfigProperties.class,
+    TurnstileCacheProperties.class,
+    TurnstileCacheConfig.class
+})
 public class TurnstileConfiguration {
 
     /**

--- a/src/main/java/com/digitalsanctuary/cf/turnstile/config/TurnstileCacheConfig.java
+++ b/src/main/java/com/digitalsanctuary/cf/turnstile/config/TurnstileCacheConfig.java
@@ -1,0 +1,67 @@
+package com.digitalsanctuary.cf.turnstile.config;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Configuration class for Turnstile caching.
+ * <p>
+ * This class configures the cache manager and related components for the Turnstile validation service.
+ * It is conditionally enabled based on the {@code ds.cf.turnstile.cache.enabled} property.
+ * </p>
+ */
+@Slf4j
+@Configuration
+@EnableCaching
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "ds.cf.turnstile.cache.enabled", havingValue = "true", matchIfMissing = true)
+public class TurnstileCacheConfig {
+
+    /**
+     * The name of the cache used for Turnstile validation results.
+     */
+    public static final String TURNSTILE_VALIDATION_CACHE = "turnstileValidationCache";
+    
+    private final TurnstileCacheProperties cacheProperties;
+
+    /**
+     * Logs the cache configuration on startup.
+     */
+    @PostConstruct
+    public void onStartup() {
+        log.info("Turnstile caching is enabled");
+        log.info("Cache TTL: {} seconds", cacheProperties.getTtlSeconds());
+        log.info("Cache max size: {} entries", cacheProperties.getMaxSize());
+        log.info("Cache successful validations only: {}", cacheProperties.isCacheSuccessOnly());
+    }
+    
+    /**
+     * Creates and configures the cache manager.
+     * 
+     * @return the configured cache manager
+     */
+    @Bean
+    public CacheManager cacheManager() {
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager(TURNSTILE_VALIDATION_CACHE);
+        
+        Caffeine<Object, Object> caffeine = Caffeine.newBuilder()
+                .expireAfterWrite(cacheProperties.getTtlSeconds(), TimeUnit.SECONDS)
+                .maximumSize(cacheProperties.getMaxSize())
+                .recordStats();
+        
+        cacheManager.setCaffeine(caffeine);
+        return cacheManager;
+    }
+}

--- a/src/main/java/com/digitalsanctuary/cf/turnstile/config/TurnstileCacheProperties.java
+++ b/src/main/java/com/digitalsanctuary/cf/turnstile/config/TurnstileCacheProperties.java
@@ -1,0 +1,52 @@
+package com.digitalsanctuary.cf.turnstile.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Data;
+
+/**
+ * Configuration properties for Turnstile caching.
+ * <p>
+ * This class defines the configuration properties for the caching functionality of the Turnstile validation service.
+ * </p>
+ * <p>
+ * By default, these properties are expected to be defined with the prefix {@code ds.cf.turnstile.cache}:
+ * </p>
+ * 
+ * <pre>
+ * ds:
+ *   cf:
+ *     turnstile:
+ *       cache:
+ *         enabled: true
+ *         ttlSeconds: 300
+ *         maxSize: 1000
+ * </pre>
+ */
+@Data
+@Component("turnstileCacheProperties")
+@ConfigurationProperties(prefix = "ds.cf.turnstile.cache")
+public class TurnstileCacheProperties {
+
+    /**
+     * Whether caching is enabled for Turnstile validation responses. Default is true.
+     */
+    private boolean enabled = true;
+
+    /**
+     * Time-to-live for cache entries in seconds. Default is 300 seconds (5 minutes).
+     */
+    private int ttlSeconds = 300;
+
+    /**
+     * Maximum number of entries in the cache. Default is 1000.
+     */
+    private int maxSize = 1000;
+
+    /**
+     * Whether to cache successful validations only. If true, only successful validations will be cached, which prevents cache poisoning. Default is
+     * true.
+     */
+    private boolean cacheSuccessOnly = true;
+}

--- a/src/main/java/com/digitalsanctuary/cf/turnstile/config/TurnstileServiceConfig.java
+++ b/src/main/java/com/digitalsanctuary/cf/turnstile/config/TurnstileServiceConfig.java
@@ -21,6 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 public class TurnstileServiceConfig {
 
     private final TurnstileConfigProperties properties;
+    private final TurnstileCacheProperties cacheProperties;
 
     /**
      * Creates a RestTemplate bean for Turnstile API interactions.
@@ -40,7 +41,7 @@ public class TurnstileServiceConfig {
      */
     @Bean
     public TurnstileValidationService turnstileValidationService() {
-        return new TurnstileValidationService(turnstileRestClient(), properties);
+        return new TurnstileValidationService(turnstileRestClient(), properties, cacheProperties);
     }
 
     /**

--- a/src/main/resources/config/turnstile.properties
+++ b/src/main/resources/config/turnstile.properties
@@ -1,3 +1,9 @@
 ds.cf.turnstile.sitekey= # Turnstile Site Key
 ds.cf.turnstile.secret= # Turnstile Secret
 ds.cf.turnstile.url=https://challenges.cloudflare.com/turnstile/v0/siteverify
+
+# Cache configuration
+ds.cf.turnstile.cache.enabled=true
+ds.cf.turnstile.cache.ttlSeconds=300
+ds.cf.turnstile.cache.maxSize=1000
+ds.cf.turnstile.cache.cacheSuccessOnly=true

--- a/src/test/java/com/digitalsanctuary/cf/test/TestApplication.java
+++ b/src/test/java/com/digitalsanctuary/cf/test/TestApplication.java
@@ -4,6 +4,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
+
 @SpringBootApplication
 public class TestApplication {
     // This class doesn't need any content, it just needs the @SpringBootApplication annotation

--- a/src/test/java/com/digitalsanctuary/cf/test/turnstile/CachingTest.java
+++ b/src/test/java/com/digitalsanctuary/cf/test/turnstile/CachingTest.java
@@ -1,0 +1,41 @@
+package com.digitalsanctuary.cf.test.turnstile;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import com.digitalsanctuary.cf.test.TestApplication;
+import com.digitalsanctuary.cf.turnstile.dto.ValidationResult;
+import com.digitalsanctuary.cf.turnstile.service.TurnstileValidationService;
+
+/**
+ * Test class dedicated to testing just the caching functionality. Uses a minimal configuration to avoid conflicts.
+ */
+
+@SpringBootTest(classes = TestApplication.class)
+@ActiveProfiles("test")
+public class CachingTest {
+
+    @Autowired
+    private TurnstileValidationService validationService;
+
+    @Test
+    public void testCachingAndBypassMethods() {
+        // Create a unique test token to ensure clean slate
+        String testToken = "0123456789012345678901234567890123456789_" + System.currentTimeMillis();
+
+        // Test caching method
+        ValidationResult result1 = validationService.validateTurnstileResponseDetailed(testToken);
+        assertTrue(result1.isSuccess(), "First validation should succeed");
+
+        // Test no-cache method
+        ValidationResult result2 = validationService.validateTurnstileResponseNoCache(testToken);
+        assertTrue(result2.isSuccess(), "No-cache validation should succeed");
+
+        // Test cached method again (should hit cache)
+        ValidationResult result3 = validationService.validateTurnstileResponseDetailed(testToken);
+        assertTrue(result3.isSuccess(), "Second cached validation should succeed");
+    }
+
+}

--- a/src/test/java/com/digitalsanctuary/cf/test/turnstile/TurnstileValidationServiceTest.java
+++ b/src/test/java/com/digitalsanctuary/cf/test/turnstile/TurnstileValidationServiceTest.java
@@ -2,21 +2,15 @@ package com.digitalsanctuary.cf.test.turnstile;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-
 import com.digitalsanctuary.cf.test.TestApplication;
 import com.digitalsanctuary.cf.turnstile.dto.ValidationResult;
 import com.digitalsanctuary.cf.turnstile.dto.ValidationResult.ValidationResultType;
-import com.digitalsanctuary.cf.turnstile.exception.TurnstileConfigurationException;
-import com.digitalsanctuary.cf.turnstile.exception.TurnstileValidationException;
 import com.digitalsanctuary.cf.turnstile.service.TurnstileValidationService;
-
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -34,73 +28,95 @@ public class TurnstileValidationServiceTest {
     public void testValidateTurnstileResponse_Success() {
         // Create a token that will pass our basic validation (length >= 20)
         String validLengthToken = "0123456789012345678901234567890123456789";
-        
+
         boolean response = turnstileValidationService.validateTurnstileResponse(validLengthToken, "127.0.0.1");
         assertTrue(response);
     }
-    
+
     @Test
     public void testValidateTurnstileResponse_NullToken() {
         boolean response = turnstileValidationService.validateTurnstileResponse(null, "127.0.0.1");
         assertFalse(response); // Should fail with null token
     }
-    
+
     @Test
     public void testValidateTurnstileResponse_EmptyToken() {
         boolean response = turnstileValidationService.validateTurnstileResponse("", "127.0.0.1");
         assertFalse(response); // Should fail with empty token
     }
-    
+
     @Test
     public void testValidateTurnstileResponse_ShortToken() {
         boolean response = turnstileValidationService.validateTurnstileResponse("12345", "127.0.0.1");
         assertFalse(response); // Should fail with token that's too short
     }
-    
+
     /**
      * Test the detailed validation method
      */
     @Test
     public void testValidateTurnstileResponseDetailed_Success() {
         // Create a token that will pass our basic validation (length >= 20)
-        String validLengthToken = "0123456789012345678901234567890123456789";
-        
+        String validLengthToken = "0123456789012345678901234567890123456799";
+
         ValidationResult result = turnstileValidationService.validateTurnstileResponseDetailed(validLengthToken, "127.0.0.1");
+        log.info("Validation result: {}", result);
         assertTrue(result.isSuccess());
         assertEquals(ValidationResultType.SUCCESS, result.getResultType());
     }
-    
+
     @Test
     public void testValidateTurnstileResponseDetailed_NullToken() {
         ValidationResult result = turnstileValidationService.validateTurnstileResponseDetailed(null, "127.0.0.1");
         assertFalse(result.isSuccess());
         assertEquals(ValidationResultType.INPUT_ERROR, result.getResultType());
     }
-    
+
     @Test
     public void testValidateTurnstileResponseDetailed_EmptyToken() {
         ValidationResult result = turnstileValidationService.validateTurnstileResponseDetailed("", "127.0.0.1");
         assertFalse(result.isSuccess());
         assertEquals(ValidationResultType.INPUT_ERROR, result.getResultType());
     }
-    
+
     @Test
     public void testValidateTurnstileResponseDetailed_ShortToken() {
         ValidationResult result = turnstileValidationService.validateTurnstileResponseDetailed("12345", "127.0.0.1");
         assertFalse(result.isSuccess());
         assertEquals(ValidationResultType.INPUT_ERROR, result.getResultType());
     }
-    
+
     @Test
     public void testConvenienceMethodWithoutIp() {
         // Create a token that will pass our basic validation (length >= 20)
         String validLengthToken = "0123456789012345678901234567890123456789";
-        
+
         // Test both the boolean and detailed methods without IP
         boolean booleanResult = turnstileValidationService.validateTurnstileResponse(validLengthToken);
         ValidationResult detailedResult = turnstileValidationService.validateTurnstileResponseDetailed(validLengthToken);
-        
+
         assertTrue(booleanResult);
         assertTrue(detailedResult.isSuccess());
+    }
+
+    /**
+     * Test the no-cache validation method
+     */
+    @Test
+    public void testNoCacheValidation() {
+        // Create a token that will pass our basic validation (length >= 20)
+        String validLengthToken = "0123456789012345678901234567890123456789";
+
+        // Test the no-cache method
+        ValidationResult noCacheResult = turnstileValidationService.validateTurnstileResponseNoCache(validLengthToken);
+        assertTrue(noCacheResult.isSuccess());
+
+        // Test the regular method
+        ValidationResult cachedResult = turnstileValidationService.validateTurnstileResponseDetailed(validLengthToken);
+        assertTrue(cachedResult.isSuccess());
+
+        // Call it again to test caching behavior
+        ValidationResult secondCachedResult = turnstileValidationService.validateTurnstileResponseDetailed(validLengthToken);
+        assertTrue(secondCachedResult.isSuccess());
     }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -3,3 +3,8 @@ ds:
     turnstile:
       sitekey: 1x00000000000000000000BB
       secret: 1x0000000000000000000000000000000AA
+      cache:
+        enabled: true
+        ttlSeconds: 60
+        maxSize: 100
+        cacheSuccessOnly: true


### PR DESCRIPTION
## Summary
- Created TurnstileCacheProperties for configuring cache behavior with TTL, size limits
- Implemented TurnstileCacheConfig with Caffeine cache provider support
- Added @Cacheable annotations with smart key generation for improved performance
- Implemented cache bypass methods with validateTurnstileResponseNoCache
- Updated imports and configuration in main application class
- Added appropriate test configuration and test cases
- Updated dependencies to include Spring Cache and Caffeine
- Added comprehensive JavaDoc documentation

## Implementation Details
- Cache configuration is fully customizable via application properties
- Cache keys are generated using token and remoteIp parameters
- Validation results are cached based on configurable TTL (default 300s)
- Maximum cache size is configurable (default 1000 entries)
- Feature can be completely disabled via configuration
- No-cache methods allow bypassing cache when needed

## Test Plan
- Added CachingTest to verify caching functionality works correctly
- Verified that same token returns cached result on subsequent calls
- Confirmed that bypass methods work correctly
- All tests pass with both JDK 17 and 21

Fixes #32