### PR TITLE
2.1.0: opt-in login filter, test-credential detection, overridable beans

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ ds:
         error-threshold: 10
       # Optional filter configuration (only needed if using TurnstileCaptchaFilter)
       login:
+        enabled: false                   # Registers TurnstileCaptchaFilter (default: false). The filter does
+                                          # nothing unless this is set to true (changed in 2.1.0).
         submissionPath: /login           # Path to intercept (default: /login)
         redirectUrl: /login?error=captcha # Redirect URL on failure
       token:
@@ -200,6 +202,14 @@ If you don't need to validate the client IP address, you can use the simplified 
 boolean turnstileValid = turnstileValidationService.validateTurnstileResponse(turnstileResponse);
 ```
 
+#### Test Credentials Detection
+
+`TurnstileValidationService.isUsingTestCredentials()` returns `true` when the configured sitekey or secret
+matches one of [Cloudflare's published test credentials](https://developers.cloudflare.com/turnstile/troubleshooting/testing/).
+Those credentials always pass (or always fail, depending on which test key you use) and provide no real bot
+protection. If test credentials are detected, the service also logs a WARN banner at startup, so an
+always-pass test key left in a production configuration doesn't go unnoticed.
+
 
 ## Security Best Practices
 
@@ -293,11 +303,14 @@ Spring Cloudflare Turnstile uses Spring Boot's auto-configuration to seamlessly 
 
 This project provides an optional helper component, **TurnstileCaptchaFilter**, which can be used to add Turnstile captcha validation to your Spring Security Form Login flow.
 
+As of 2.1.0, this filter is opt-in: it is only registered when `ds.cf.turnstile.login.enabled=true`. Previously it registered automatically whenever the library was on the classpath. If you rely on this filter, set `ds.cf.turnstile.login.enabled=true` when upgrading.
+
 ### Configuration
 
 Configure the following properties in your `application.properties` or `application.yml`:
 
 ```properties
+ds.cf.turnstile.login.enabled=true
 ds.cf.turnstile.login.submissionPath=/login
 ds.cf.turnstile.login.redirectUrl=/login?error=captcha
 ds.cf.turnstile.token.parameterName=cf-turnstile-response
@@ -305,7 +318,7 @@ ds.cf.turnstile.token.parameterName=cf-turnstile-response
 
 ### Integration with Spring Security
 
-To use the filter with form login, add it to your security configuration before the default authentication filter:
+To use the filter with form login, add it to your security configuration before the default authentication filter. The `TurnstileCaptchaFilter` bean only exists when `ds.cf.turnstile.login.enabled=true`, so autowiring it as shown below requires that property to be set:
 
 ```java
 @Configuration
@@ -336,7 +349,7 @@ public class SecurityConfig {
 - The filter checks if the request's servlet path matches the configured login submission path and that the HTTP method is POST.
 - It validates the captcha token (expected to be sent under the configured parameter name) using the TurnstileValidationService.
 - On a successful captcha validation, the request continues through the filter chain. Otherwise, it logs a warning and redirects to the login page.
-- This component is completely optional; if you do not require captcha validation for your login flow, do not enable or configure this filter.
+- This component is opt-in: it is not registered unless `ds.cf.turnstile.login.enabled=true`. If you do not require captcha validation for your login flow, leave this property unset (or `false`) and the filter will not be created.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Choose the library version based on your Spring Boot version:
 
 | Library Version | Spring Boot | Status |
 |----------------|-------------|--------|
-| 2.0.x          | 4.0.x       | Current |
+| 2.1.x          | 4.0.x       | Current |
 | 1.3.x          | 3.5.x       | Maintenance |
 
 ### Quick Start
@@ -53,7 +53,7 @@ Add the following dependency to your `pom.xml`:
 <dependency>
     <groupId>com.digitalsanctuary</groupId>
     <artifactId>ds-spring-cf-turnstile</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0</version>
 </dependency>
 ```
 
@@ -63,7 +63,7 @@ Add the following dependency to your `build.gradle`:
 
 ```groovy
 dependencies {
-    implementation 'com.digitalsanctuary:ds-spring-cf-turnstile:2.0.1'
+    implementation 'com.digitalsanctuary:ds-spring-cf-turnstile:2.1.0'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -91,12 +91,13 @@ ds:
         error-threshold: 10
       # Optional filter configuration (only needed if using TurnstileCaptchaFilter)
       login:
-        enabled: false                   # Registers TurnstileCaptchaFilter (default: false). The filter does
-                                          # nothing unless this is set to true (changed in 2.1.0).
-        submissionPath: /login           # Path to intercept (default: /login)
-        redirectUrl: /login?error=captcha # Redirect URL on failure
+        enabled: true                     # Creates the TurnstileCaptchaFilter bean. Defaults to false;
+                                          # unless this is true the filter bean is not created at all
+                                          # (changed in 2.1.0), and injecting it fails startup.
+        submission-path: /login           # Path to intercept (default: /login)
+        redirect-url: /login?error=captcha # Redirect URL on failure
       token:
-        parameterName: cf-turnstile-response  # Token parameter name (default)
+        parameter-name: cf-turnstile-response  # Token parameter name (default)
 ```
 
 
@@ -311,10 +312,12 @@ Configure the following properties in your `application.properties` or `applicat
 
 ```properties
 ds.cf.turnstile.login.enabled=true
-ds.cf.turnstile.login.submissionPath=/login
-ds.cf.turnstile.login.redirectUrl=/login?error=captcha
-ds.cf.turnstile.token.parameterName=cf-turnstile-response
+ds.cf.turnstile.login.submission-path=/login
+ds.cf.turnstile.login.redirect-url=/login?error=captcha
+ds.cf.turnstile.token.parameter-name=cf-turnstile-response
 ```
+
+The camelCase forms (`submissionPath`, `redirectUrl`, `parameterName`) used in earlier README versions still bind via Spring's relaxed binding, so existing configuration keeps working.
 
 ### Integration with Spring Security
 

--- a/docs/RELEASE-NOTES-2.1.0.md
+++ b/docs/RELEASE-NOTES-2.1.0.md
@@ -1,0 +1,24 @@
+# 2.1.0
+
+## Behavior change
+
+- `TurnstileCaptchaFilter` is now opt-in. It registers only when
+  `ds.cf.turnstile.login.enabled=true`. Previously it registered automatically whenever the
+  library was on the classpath, intercepting POSTs to `ds.cf.turnstile.login.submissionPath`
+  (default `/login`). **If you use the login filter, add `ds.cf.turnstile.login.enabled=true`
+  when upgrading.** If you only use `TurnstileValidationService` directly, no change is needed.
+
+## New
+
+- `TurnstileValidationService.isUsingTestCredentials()` — returns true when the configured
+  sitekey or secret is one of Cloudflare's published test credentials. The service also logs a
+  WARN banner at startup in that case, so always-pass test keys cannot reach production
+  unnoticed.
+
+## Fixed
+
+- `turnstileValidationService` and `turnstileRestClient` beans are now `@ConditionalOnMissingBean`,
+  so consumers can supply their own implementations without a bean-definition conflict. (The
+  RestClient condition is name-based: only a bean named `turnstileRestClient` overrides it.)
+
+(#106)

--- a/docs/RELEASE-NOTES-2.1.0.md
+++ b/docs/RELEASE-NOTES-2.1.0.md
@@ -4,7 +4,7 @@
 
 - `TurnstileCaptchaFilter` is now opt-in. It registers only when
   `ds.cf.turnstile.login.enabled=true`. Previously it registered automatically whenever the
-  library was on the classpath, intercepting POSTs to `ds.cf.turnstile.login.submissionPath`
+  library was on the classpath, intercepting POSTs to `ds.cf.turnstile.login.submission-path`
   (default `/login`). **If you use the login filter, add `ds.cf.turnstile.login.enabled=true`
   when upgrading.** If you only use `TurnstileValidationService` directly, no change is needed.
   Apps that inject `TurnstileCaptchaFilter` directly (e.g. into a `SecurityFilterChain`, per

--- a/docs/RELEASE-NOTES-2.1.0.md
+++ b/docs/RELEASE-NOTES-2.1.0.md
@@ -7,6 +7,9 @@
   library was on the classpath, intercepting POSTs to `ds.cf.turnstile.login.submissionPath`
   (default `/login`). **If you use the login filter, add `ds.cf.turnstile.login.enabled=true`
   when upgrading.** If you only use `TurnstileValidationService` directly, no change is needed.
+  Apps that inject `TurnstileCaptchaFilter` directly (e.g. into a `SecurityFilterChain`, per
+  the old README pattern) will fail startup with `NoSuchBeanDefinitionException` until
+  `ds.cf.turnstile.login.enabled=true` is set.
 
 ## New
 
@@ -18,7 +21,11 @@
 ## Fixed
 
 - `turnstileValidationService` and `turnstileRestClient` beans are now `@ConditionalOnMissingBean`,
-  so consumers can supply their own implementations without a bean-definition conflict. (The
-  RestClient condition is name-based: only a bean named `turnstileRestClient` overrides it.)
+  so consumers can supply their own implementations without a bean-definition conflict.
+  `TurnstileValidationService` is a concrete class with no interface, so overriding it means
+  supplying your own instance of that class or a subclass — the library's health indicator and
+  metrics then reflect whichever `TurnstileValidationService` bean is active, library-provided
+  or consumer-supplied. (The RestClient condition is name-based: only a bean named
+  `turnstileRestClient` overrides it.)
 
 (#106)

--- a/docs/RELEASE-NOTES-2.1.0.md
+++ b/docs/RELEASE-NOTES-2.1.0.md
@@ -11,21 +11,42 @@
   the old README pattern) will fail startup with `NoSuchBeanDefinitionException` until
   `ds.cf.turnstile.login.enabled=true` is set.
 
+  Apps that relied on the filter being auto-registered with the servlet container — that is,
+  they never injected it anywhere — get **no** startup error. The filter is simply absent and
+  POSTs to the login submission path are no longer captcha-checked. Two things limit the blast
+  radius: the startup log now states the filter's registration state explicitly
+  (`Turnstile login captcha filter (ds.cf.turnstile.login.enabled): ENABLED|DISABLED`), and
+  Spring Security form-login apps were not effectively protected by the auto-registered filter
+  anyway — as a plain servlet filter it ran behind the security filter chain, after
+  authentication had already been processed.
+
 ## New
 
 - `TurnstileValidationService.isUsingTestCredentials()` — returns true when the configured
-  sitekey or secret is one of Cloudflare's published test credentials. The service also logs a
-  WARN banner at startup in that case, so always-pass test keys cannot reach production
-  unnoticed.
+  sitekey or secret is one of Cloudflare's published test credentials. A WARN banner is logged
+  at startup in that case, so test keys cannot reach production unnoticed. Depending on the key
+  those credentials make validation always pass (no bot protection) or always fail (all users
+  blocked).
+- The turnstile actuator health contributor reports a `usingTestCredentials` detail, so the same
+  condition is visible on a running deployment and not only in the startup log.
+- Startup reporting (missing secret/URL errors, the test-credential banner, and the login filter
+  registration state) now runs from a `TurnstileStartupReporter` bean that is registered
+  unconditionally, so these checks survive a consumer overriding the service bean.
 
 ## Fixed
 
 - `turnstileValidationService` and `turnstileRestClient` beans are now `@ConditionalOnMissingBean`,
   so consumers can supply their own implementations without a bean-definition conflict.
   `TurnstileValidationService` is a concrete class with no interface, so overriding it means
-  supplying your own instance of that class or a subclass — the library's health indicator and
-  metrics then reflect whichever `TurnstileValidationService` bean is active, library-provided
-  or consumer-supplied. (The RestClient condition is name-based: only a bean named
-  `turnstileRestClient` overrides it.)
+  supplying your own instance of that class or a subclass. Note what this does *not* buy you: the
+  built-in counters only move when the library's own validation methods run, so a subclass that
+  overrides validation without delegating to `super` leaves health permanently UP with zero
+  counts and flat metrics. Either delegate to `super` or override the counter getters
+  (`getValidationCount()`, `getErrorRate()`, and friends). (The RestClient condition is
+  name-based: only a bean named `turnstileRestClient` overrides it.)
+- The login filter's settings are bound through `TurnstileConfigProperties` instead of `@Value`
+  placeholders. The kebab-case names published in the configuration metadata
+  (`ds.cf.turnstile.login.submission-path`, `login.redirect-url`, `token.parameter-name`) were
+  silently ignored before; they now work, and the camelCase forms still bind via relaxed binding.
 
 (#106)

--- a/src/main/java/com/digitalsanctuary/cf/turnstile/TurnstileConfiguration.java
+++ b/src/main/java/com/digitalsanctuary/cf/turnstile/TurnstileConfiguration.java
@@ -1,14 +1,17 @@
 package com.digitalsanctuary.cf.turnstile;
 
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.health.autoconfigure.contributor.ConditionalOnEnabledHealthIndicator;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import com.digitalsanctuary.cf.turnstile.config.TurnstileConfigProperties;
 import com.digitalsanctuary.cf.turnstile.config.TurnstileHealthIndicator;
 import com.digitalsanctuary.cf.turnstile.config.TurnstileMetricsConfig;
 import com.digitalsanctuary.cf.turnstile.config.TurnstileServiceConfig;
+import com.digitalsanctuary.cf.turnstile.config.TurnstileStartupReporter;
 import com.digitalsanctuary.cf.turnstile.filter.TurnstileCaptchaFilter;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
@@ -56,6 +59,20 @@ public class TurnstileConfiguration {
     @ConditionalOnClass(name = "org.springframework.boot.health.contributor.HealthIndicator")
     @Import(TurnstileHealthIndicator.class)
     static class TurnstileHealthConfiguration {
+    }
+
+    /**
+     * Registers the startup reporter unconditionally, so configuration problems (missing secret or URL, Cloudflare test credentials) and the login
+     * filter registration state are always reported — even when the consuming application overrides the library's service bean.
+     *
+     * @param properties the Turnstile configuration properties
+     * @param captchaFilterProvider provider used to detect whether the login captcha filter bean is registered
+     * @return the startup reporter
+     */
+    @Bean
+    public TurnstileStartupReporter turnstileStartupReporter(TurnstileConfigProperties properties,
+            ObjectProvider<TurnstileCaptchaFilter> captchaFilterProvider) {
+        return new TurnstileStartupReporter(properties, captchaFilterProvider);
     }
 
     /**

--- a/src/main/java/com/digitalsanctuary/cf/turnstile/config/TurnstileConfigProperties.java
+++ b/src/main/java/com/digitalsanctuary/cf/turnstile/config/TurnstileConfigProperties.java
@@ -72,6 +72,16 @@ public class TurnstileConfigProperties {
     private Metrics metrics = new Metrics();
 
     /**
+     * Configuration for the optional login captcha filter.
+     */
+    private Login login = new Login();
+
+    /**
+     * Configuration for the Turnstile token request parameter.
+     */
+    private Token token = new Token();
+
+    /**
      * Nested class for metrics configuration properties.
      */
     @Data
@@ -93,5 +103,42 @@ public class TurnstileConfigProperties {
          * Defaults to 10.
          */
         private int errorThreshold = 10;
+    }
+
+    /**
+     * Nested class for the optional {@link com.digitalsanctuary.cf.turnstile.filter.TurnstileCaptchaFilter} configuration properties.
+     */
+    @Data
+    public static class Login {
+
+        /**
+         * Whether the login captcha filter is registered. Defaults to false; since 2.1.0 the filter
+         * is created only when this is explicitly set to true.
+         */
+        private boolean enabled = false;
+
+        /**
+         * The servlet path the login captcha filter intercepts. Defaults to {@code /login}.
+         */
+        private String submissionPath = "/login";
+
+        /**
+         * The URL the login captcha filter redirects to when captcha validation fails.
+         * Defaults to {@code /login?error=captcha}.
+         */
+        private String redirectUrl = "/login?error=captcha";
+    }
+
+    /**
+     * Nested class for Turnstile token request parameter configuration properties.
+     */
+    @Data
+    public static class Token {
+
+        /**
+         * The name of the request parameter carrying the Turnstile token.
+         * Defaults to {@code cf-turnstile-response}.
+         */
+        private String parameterName = "cf-turnstile-response";
     }
 }

--- a/src/main/java/com/digitalsanctuary/cf/turnstile/config/TurnstileHealthIndicator.java
+++ b/src/main/java/com/digitalsanctuary/cf/turnstile/config/TurnstileHealthIndicator.java
@@ -46,7 +46,8 @@ public class TurnstileHealthIndicator implements HealthIndicator {
                     Health.up().withDetail("url", properties.getUrl()).withDetail("validationCount", validationService.getValidationCount())
                             .withDetail("successCount", validationService.getSuccessCount())
                             .withDetail("errorCount", validationService.getErrorCount()).withDetail("errorRate", String.format("%.2f%%", errorRate))
-                            .withDetail("responseTimeAvg", String.format("%.2fms", validationService.getAverageResponseTime()));
+                            .withDetail("responseTimeAvg", String.format("%.2fms", validationService.getAverageResponseTime()))
+                            .withDetail("usingTestCredentials", validationService.isUsingTestCredentials());
 
             // If error rate exceeds threshold, report as DOWN
             if (errorRate > errorThreshold) {

--- a/src/main/java/com/digitalsanctuary/cf/turnstile/config/TurnstileServiceConfig.java
+++ b/src/main/java/com/digitalsanctuary/cf/turnstile/config/TurnstileServiceConfig.java
@@ -43,12 +43,17 @@ public class TurnstileServiceConfig {
 
     /**
      * Creates a TurnstileValidationService bean.
+     * <p>
+     * Backs off if the consuming application supplies its own {@link TurnstileValidationService}
+     * bean, regardless of that bean's name.
+     * </p>
      *
      * @param restClient the preconfigured REST client for Turnstile calls
      * @param metrics the TurnstileMetrics implementation to use
      * @return a configured TurnstileValidationService instance
      */
     @Bean
+    @ConditionalOnMissingBean(TurnstileValidationService.class)
     public TurnstileValidationService turnstileValidationService(
             @Qualifier("turnstileRestClient") RestClient restClient,
             TurnstileMetrics metrics) {
@@ -57,10 +62,17 @@ public class TurnstileServiceConfig {
 
     /**
      * Creates a RestClient bean for Turnstile API interactions.
+     * <p>
+     * Backs off only when the consuming application defines its own bean named
+     * {@code turnstileRestClient}; a type-based check is deliberately avoided here so that an
+     * unrelated {@link RestClient} bean elsewhere in the application does not silently disable
+     * Turnstile validation.
+     * </p>
      *
      * @return a configured RestClient instance
      */
     @Bean(name = "turnstileRestClient")
+    @ConditionalOnMissingBean(name = "turnstileRestClient")
     public RestClient turnstileRestClient() {
         log.info("Creating Turnstile REST client with endpoint: {}", properties.getUrl());
         log.info("Turnstile REST client timeouts - connect: {}s, read: {}s",

--- a/src/main/java/com/digitalsanctuary/cf/turnstile/config/TurnstileStartupReporter.java
+++ b/src/main/java/com/digitalsanctuary/cf/turnstile/config/TurnstileStartupReporter.java
@@ -1,0 +1,58 @@
+package com.digitalsanctuary.cf.turnstile.config;
+
+import org.springframework.beans.factory.ObjectProvider;
+import com.digitalsanctuary.cf.turnstile.filter.TurnstileCaptchaFilter;
+import com.digitalsanctuary.cf.turnstile.service.TurnstileValidationService;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Reports the Turnstile configuration state once, at application startup.
+ * <p>
+ * This bean is registered unconditionally by the library's auto-configuration, so the checks below run even when a consuming application supplies its
+ * own {@link TurnstileValidationService} bean. It logs missing required configuration at ERROR, warns when Cloudflare test credentials are in use, and
+ * reports whether the login captcha filter is registered.
+ * </p>
+ */
+@Slf4j
+public class TurnstileStartupReporter {
+
+    private final TurnstileConfigProperties properties;
+    private final ObjectProvider<TurnstileCaptchaFilter> captchaFilterProvider;
+
+    /**
+     * Constructor for TurnstileStartupReporter.
+     *
+     * @param properties the Turnstile configuration properties to report on
+     * @param captchaFilterProvider provider used to detect whether the login captcha filter bean is registered
+     */
+    public TurnstileStartupReporter(TurnstileConfigProperties properties, ObjectProvider<TurnstileCaptchaFilter> captchaFilterProvider) {
+        this.properties = properties;
+        this.captchaFilterProvider = captchaFilterProvider;
+    }
+
+    /**
+     * Logs the Turnstile startup state: missing required configuration, Cloudflare test-credential usage, and login captcha filter registration state.
+     */
+    @PostConstruct
+    public void reportStartupState() {
+        if (properties.getSecret() == null || properties.getSecret().isBlank()) {
+            log.error("Turnstile secret key is not configured. Validation will fail.");
+        }
+        if (properties.getUrl() == null || properties.getUrl().isBlank()) {
+            log.error("Turnstile URL is not configured. Validation will fail.");
+        }
+
+        if (TurnstileValidationService.isTestCredentials(properties.getSitekey(), properties.getSecret())) {
+            log.warn("========================================================");
+            log.warn("Turnstile is configured with Cloudflare TEST credentials.");
+            log.warn("Depending on the key, validation will either always pass (NO bot");
+            log.warn("protection) or always fail (ALL users blocked).");
+            log.warn("Do not use these credentials in production.");
+            log.warn("========================================================");
+        }
+
+        log.info("Turnstile login captcha filter (ds.cf.turnstile.login.enabled): {}",
+                captchaFilterProvider.getIfAvailable() != null ? "ENABLED" : "DISABLED");
+    }
+}

--- a/src/main/java/com/digitalsanctuary/cf/turnstile/filter/TurnstileCaptchaFilter.java
+++ b/src/main/java/com/digitalsanctuary/cf/turnstile/filter/TurnstileCaptchaFilter.java
@@ -2,6 +2,7 @@ package com.digitalsanctuary.cf.turnstile.filter;
 
 import java.io.IOException;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -25,6 +26,8 @@ import lombok.extern.slf4j.Slf4j;
  *
  * Configuration properties:
  * <ul>
+ * <li><b>ds.cf.turnstile.login.enabled</b>: Whether this filter is registered at all (default: <code>false</code>). Since 2.1.0, the filter
+ * registers only when this property is explicitly set to <code>true</code>.</li>
  * <li><b>ds.cf.turnstile.login.submissionPath</b>: The path to intercept for login submissions (default: <code>/login</code>).</li>
  * <li><b>ds.cf.turnstile.login.redirectUrl</b>: The URL to redirect to when captcha validation fails (default:
  * <code>/login?error=captcha</code>).</li>
@@ -38,6 +41,7 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 @Component
+@ConditionalOnProperty(name = "ds.cf.turnstile.login.enabled", havingValue = "true", matchIfMissing = false)
 @RequiredArgsConstructor
 public class TurnstileCaptchaFilter extends OncePerRequestFilter {
 

--- a/src/main/java/com/digitalsanctuary/cf/turnstile/filter/TurnstileCaptchaFilter.java
+++ b/src/main/java/com/digitalsanctuary/cf/turnstile/filter/TurnstileCaptchaFilter.java
@@ -1,11 +1,11 @@
 package com.digitalsanctuary.cf.turnstile.filter;
 
 import java.io.IOException;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+import com.digitalsanctuary.cf.turnstile.config.TurnstileConfigProperties;
 import com.digitalsanctuary.cf.turnstile.service.TurnstileValidationService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -28,10 +28,10 @@ import lombok.extern.slf4j.Slf4j;
  * <ul>
  * <li><b>ds.cf.turnstile.login.enabled</b>: Whether this filter is registered at all (default: <code>false</code>). Since 2.1.0, the filter
  * registers only when this property is explicitly set to <code>true</code>.</li>
- * <li><b>ds.cf.turnstile.login.submissionPath</b>: The path to intercept for login submissions (default: <code>/login</code>).</li>
- * <li><b>ds.cf.turnstile.login.redirectUrl</b>: The URL to redirect to when captcha validation fails (default:
+ * <li><b>ds.cf.turnstile.login.submission-path</b>: The path to intercept for login submissions (default: <code>/login</code>).</li>
+ * <li><b>ds.cf.turnstile.login.redirect-url</b>: The URL to redirect to when captcha validation fails (default:
  * <code>/login?error=captcha</code>).</li>
- * <li><b>ds.cf.turnstile.token.parameterName</b>: The name of the request parameter containing the Turnstile token (default:
+ * <li><b>ds.cf.turnstile.token.parameter-name</b>: The name of the request parameter containing the Turnstile token (default:
  * <code>cf-turnstile-response</code>).</li>
  * </ul>
  *
@@ -47,14 +47,7 @@ public class TurnstileCaptchaFilter extends OncePerRequestFilter {
 
     private final TurnstileValidationService validationService;
 
-    @Value("${ds.cf.turnstile.login.submissionPath:/login}")
-    private String loginSubmissionPath;
-
-    @Value("${ds.cf.turnstile.login.redirectUrl:/login?error=captcha}")
-    private String loginRedirectUrl;
-
-    @Value("${ds.cf.turnstile.token.parameterName:cf-turnstile-response}")
-    private String turnstileTokenParameterName;
+    private final TurnstileConfigProperties properties;
 
     /**
      * Filters incoming HTTP requests to validate the Turnstile captcha token during login submissions.
@@ -73,14 +66,14 @@ public class TurnstileCaptchaFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response,
             @NonNull FilterChain filterChain) throws ServletException, IOException {
-        if (request.getServletPath().equals(loginSubmissionPath) && "POST".equalsIgnoreCase(request.getMethod())) {
-            String token = request.getParameter(turnstileTokenParameterName);
+        if (request.getServletPath().equals(properties.getLogin().getSubmissionPath()) && "POST".equalsIgnoreCase(request.getMethod())) {
+            String token = request.getParameter(properties.getToken().getParameterName());
             boolean valid = validationService.validateTurnstileResponse(token, getClientIp(request));
             if (valid) {
                 filterChain.doFilter(request, response);
             } else {
                 log.warn("Turnstile captcha validation failed for request: {}", request.getServletPath());
-                response.sendRedirect(loginRedirectUrl);
+                response.sendRedirect(properties.getLogin().getRedirectUrl());
             }
         } else {
             filterChain.doFilter(request, response);

--- a/src/main/java/com/digitalsanctuary/cf/turnstile/service/TurnstileValidationService.java
+++ b/src/main/java/com/digitalsanctuary/cf/turnstile/service/TurnstileValidationService.java
@@ -3,6 +3,7 @@ package com.digitalsanctuary.cf.turnstile.service;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -37,6 +38,15 @@ import lombok.extern.slf4j.Slf4j;
 public class TurnstileValidationService {
     private static final String UNKNOWN = "unknown";
     private static final int MIN_TOKEN_LENGTH = 20;
+
+    /** Cloudflare's published test sitekeys (always-pass, always-fail, interactive). */
+    private static final Set<String> CLOUDFLARE_TEST_SITEKEYS = Set.of("1x00000000000000000000AA",
+            "2x00000000000000000000AB", "1x00000000000000000000BB", "2x00000000000000000000BB",
+            "3x00000000000000000000FF");
+
+    /** Cloudflare's published test secrets (always-pass, always-fail, token-spent). */
+    private static final Set<String> CLOUDFLARE_TEST_SECRETS = Set.of("1x0000000000000000000000000000000AA",
+            "2x0000000000000000000000000000000AA", "3x0000000000000000000000000000000AA");
 
     private final RestClient turnstileRestClient;
     private final TurnstileConfigProperties properties;
@@ -88,6 +98,28 @@ public class TurnstileValidationService {
         if (properties.getUrl() == null || properties.getUrl().isBlank()) {
             log.error("Turnstile URL is not configured. Validation will fail.");
         }
+
+        if (isUsingTestCredentials()) {
+            log.warn("========================================================");
+            log.warn("Turnstile is configured with Cloudflare TEST credentials.");
+            log.warn("Captcha validation is running in test mode and provides NO protection.");
+            log.warn("Do not use these credentials in production.");
+            log.warn("========================================================");
+        }
+    }
+
+    /**
+     * Returns true when the configured sitekey or secret is one of Cloudflare's published test
+     * credentials (see https://developers.cloudflare.com/turnstile/troubleshooting/testing/),
+     * meaning validation is running in test mode and provides no real protection.
+     *
+     * @return true if the configured credentials are Cloudflare test credentials
+     */
+    public boolean isUsingTestCredentials() {
+        String sitekey = properties.getSitekey();
+        String secret = properties.getSecret();
+        return (sitekey != null && CLOUDFLARE_TEST_SITEKEYS.contains(sitekey))
+                || (secret != null && CLOUDFLARE_TEST_SECRETS.contains(secret));
     }
 
     /**

--- a/src/main/java/com/digitalsanctuary/cf/turnstile/service/TurnstileValidationService.java
+++ b/src/main/java/com/digitalsanctuary/cf/turnstile/service/TurnstileValidationService.java
@@ -39,12 +39,16 @@ public class TurnstileValidationService {
     private static final String UNKNOWN = "unknown";
     private static final int MIN_TOKEN_LENGTH = 20;
 
-    /** Cloudflare's published test sitekeys (always-pass, always-fail, interactive). */
+    /**
+     * Cloudflare's published test sitekeys. Depending on the key these always pass (1x), always fail (2x), or force an interactive challenge (3x).
+     */
     private static final Set<String> CLOUDFLARE_TEST_SITEKEYS = Set.of("1x00000000000000000000AA",
             "2x00000000000000000000AB", "1x00000000000000000000BB", "2x00000000000000000000BB",
             "3x00000000000000000000FF");
 
-    /** Cloudflare's published test secrets (always-pass, always-fail, token-spent). */
+    /**
+     * Cloudflare's published test secrets. Depending on the secret these always pass (1x), always fail (2x), or report a spent token (3x).
+     */
     private static final Set<String> CLOUDFLARE_TEST_SECRETS = Set.of("1x0000000000000000000000000000000AA",
             "2x0000000000000000000000000000000AA", "3x0000000000000000000000000000000AA");
 
@@ -79,9 +83,12 @@ public class TurnstileValidationService {
     }
 
     /**
-     * Method called after the bean is initialized. Logs the startup information and validates the required configuration.
-     *
-     * @throws TurnstileConfigurationException if required configuration properties are missing
+     * Method called after the bean is initialized. Logs the resolved Turnstile configuration.
+     * <p>
+     * Configuration problem reporting (missing secret or URL, Cloudflare test credentials in use) lives in
+     * {@link com.digitalsanctuary.cf.turnstile.config.TurnstileStartupReporter}, which is registered unconditionally so those checks still run when a
+     * consuming application supplies its own {@code TurnstileValidationService} bean.
+     * </p>
      */
     @PostConstruct
     public void onStartup() {
@@ -91,33 +98,31 @@ public class TurnstileValidationService {
         log.info("Turnstile Secret: {}", properties.getSecret() != null && !properties.getSecret().isBlank() ? "[CONFIGURED]" : "[NOT CONFIGURED]");
         log.info("Turnstile Metrics enabled: {}", properties.getMetrics().isEnabled());
         log.info("Turnstile Health Check enabled: {}", properties.getMetrics().isHealthCheckEnabled());
-
-        if (properties.getSecret() == null || properties.getSecret().isBlank()) {
-            log.error("Turnstile secret key is not configured. Validation will fail.");
-        }
-        if (properties.getUrl() == null || properties.getUrl().isBlank()) {
-            log.error("Turnstile URL is not configured. Validation will fail.");
-        }
-
-        if (isUsingTestCredentials()) {
-            log.warn("========================================================");
-            log.warn("Turnstile is configured with Cloudflare TEST credentials.");
-            log.warn("Captcha validation is running in test mode and provides NO protection.");
-            log.warn("Do not use these credentials in production.");
-            log.warn("========================================================");
-        }
     }
 
     /**
      * Returns true when the configured sitekey or secret is one of Cloudflare's published test
-     * credentials (see https://developers.cloudflare.com/turnstile/troubleshooting/testing/),
-     * meaning validation is running in test mode and provides no real protection.
+     * credentials (see https://developers.cloudflare.com/turnstile/troubleshooting/testing/).
+     * Such credentials make validation always pass or always fail, depending on the key, so they
+     * must never be used in production.
      *
      * @return true if the configured credentials are Cloudflare test credentials
      */
     public boolean isUsingTestCredentials() {
-        String sitekey = properties.getSitekey();
-        String secret = properties.getSecret();
+        return isTestCredentials(properties.getSitekey(), properties.getSecret());
+    }
+
+    /**
+     * Returns true when the supplied sitekey or secret is one of Cloudflare's published test
+     * credentials (see https://developers.cloudflare.com/turnstile/troubleshooting/testing/).
+     * Such credentials make validation always pass or always fail, depending on the key, so they
+     * must never be used in production. Both arguments are null-safe.
+     *
+     * @param sitekey the configured Turnstile sitekey, may be null
+     * @param secret the configured Turnstile secret, may be null
+     * @return true if either value is a Cloudflare test credential
+     */
+    public static boolean isTestCredentials(String sitekey, String secret) {
         return (sitekey != null && CLOUDFLARE_TEST_SITEKEYS.contains(sitekey))
                 || (secret != null && CLOUDFLARE_TEST_SECRETS.contains(secret));
     }

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -47,6 +47,12 @@
             "defaultValue": 10
         },
         {
+            "name": "ds.cf.turnstile.login.enabled",
+            "type": "java.lang.Boolean",
+            "description": "Register the TurnstileCaptchaFilter to validate captcha tokens on login form submissions. Off by default since 2.1.0; set to true to enable the filter.",
+            "defaultValue": false
+        },
+        {
             "name": "ds.cf.turnstile.login.submission-path",
             "type": "java.lang.String",
             "description": "Path to intercept for login submissions when using TurnstileCaptchaFilter",

--- a/src/main/resources/config/turnstile.properties
+++ b/src/main/resources/config/turnstile.properties
@@ -8,10 +8,9 @@ ds.cf.turnstile.url=https://challenges.cloudflare.com/turnstile/v0/siteverify
 ds.cf.turnstile.connect-timeout=5
 ds.cf.turnstile.read-timeout=10
 
-# Configuration for TurnstileCaptchaFilter component (for use with Spring Security Form Login, etc...)
-ds.cf.turnstile.login.submissionPath=/login
-ds.cf.turnstile.login.redirectUrl=/login?error=captcha
-ds.cf.turnstile.token.parameterName=cf-turnstile-response
+# Configuration for the TurnstileCaptchaFilter component (for use with Spring Security Form Login,
+# etc...) is bound from ds.cf.turnstile.login.* and ds.cf.turnstile.token.*; the defaults live in the
+# TurnstileConfigProperties.Login / TurnstileConfigProperties.Token field initializers.
 
 # Monitoring and metrics configuration
 ds.cf.turnstile.metrics.enabled=true

--- a/src/test/java/com/digitalsanctuary/cf/test/turnstile/TurnstileBeanOverrideTest.java
+++ b/src/test/java/com/digitalsanctuary/cf/test/turnstile/TurnstileBeanOverrideTest.java
@@ -14,6 +14,7 @@ import org.springframework.web.client.RestClient;
 
 import com.digitalsanctuary.cf.turnstile.TurnstileConfiguration;
 import com.digitalsanctuary.cf.turnstile.config.TurnstileConfigProperties;
+import com.digitalsanctuary.cf.turnstile.config.TurnstileStartupReporter;
 import com.digitalsanctuary.cf.turnstile.metrics.TurnstileMetrics;
 import com.digitalsanctuary.cf.turnstile.service.TurnstileValidationService;
 
@@ -40,6 +41,9 @@ class TurnstileBeanOverrideTest {
             assertThat(context).hasNotFailed();
             assertThat(context).hasSingleBean(TurnstileValidationService.class);
             assertThat(context).hasBean("customTurnstileValidationService");
+            // The startup reporter must stay unconditional: overriding the service is exactly the case
+            // that used to lose the missing-config and test-credential checks.
+            assertThat(context).hasSingleBean(TurnstileStartupReporter.class);
         });
     }
 

--- a/src/test/java/com/digitalsanctuary/cf/test/turnstile/TurnstileBeanOverrideTest.java
+++ b/src/test/java/com/digitalsanctuary/cf/test/turnstile/TurnstileBeanOverrideTest.java
@@ -4,13 +4,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAutoConfiguration;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestClient;
 
 import com.digitalsanctuary.cf.turnstile.TurnstileConfiguration;
+import com.digitalsanctuary.cf.turnstile.config.TurnstileConfigProperties;
+import com.digitalsanctuary.cf.turnstile.metrics.TurnstileMetrics;
 import com.digitalsanctuary.cf.turnstile.service.TurnstileValidationService;
 
 /**
@@ -19,8 +23,8 @@ import com.digitalsanctuary.cf.turnstile.service.TurnstileValidationService;
  */
 class TurnstileBeanOverrideTest {
 
-    private final WebApplicationContextRunner contextRunner =
-            new WebApplicationContextRunner().withConfiguration(AutoConfigurations.of(TurnstileConfiguration.class));
+    private final WebApplicationContextRunner contextRunner = new WebApplicationContextRunner().withConfiguration(
+            AutoConfigurations.of(ConfigurationPropertiesAutoConfiguration.class, TurnstileConfiguration.class));
 
     @Configuration
     static class CustomServiceConfiguration {
@@ -45,6 +49,36 @@ class TurnstileBeanOverrideTest {
             assertThat(context).hasNotFailed();
             assertThat(context).hasSingleBean(TurnstileValidationService.class);
             assertThat(context).hasBean("turnstileValidationService");
+        });
+    }
+
+    /**
+     * A consumer subclass of the concrete service, the realistic override shape: it inherits the
+     * library's counters and startup hook rather than stubbing them out like a mock does.
+     */
+    static class CountingTurnstileValidationService extends TurnstileValidationService {
+        CountingTurnstileValidationService(RestClient restClient, TurnstileConfigProperties properties, TurnstileMetrics metrics) {
+            super(restClient, properties, metrics);
+        }
+    }
+
+    @Configuration
+    static class SubclassServiceConfiguration {
+        @Bean
+        TurnstileValidationService countingTurnstileValidationService(@Qualifier("turnstileRestClient") RestClient restClient,
+                TurnstileConfigProperties properties, TurnstileMetrics metrics) {
+            return new CountingTurnstileValidationService(restClient, properties, metrics);
+        }
+    }
+
+    @Test
+    void consumerSubclassInstanceReplacesDefault() {
+        contextRunner.withUserConfiguration(SubclassServiceConfiguration.class).run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(context).hasSingleBean(TurnstileValidationService.class);
+            assertThat(context).hasBean("countingTurnstileValidationService");
+            assertThat(context).doesNotHaveBean("turnstileValidationService");
+            assertThat(context.getBean(TurnstileValidationService.class)).isInstanceOf(CountingTurnstileValidationService.class);
         });
     }
 

--- a/src/test/java/com/digitalsanctuary/cf/test/turnstile/TurnstileBeanOverrideTest.java
+++ b/src/test/java/com/digitalsanctuary/cf/test/turnstile/TurnstileBeanOverrideTest.java
@@ -8,6 +8,7 @@ import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
 
 import com.digitalsanctuary.cf.turnstile.TurnstileConfiguration;
 import com.digitalsanctuary.cf.turnstile.service.TurnstileValidationService;
@@ -44,6 +45,42 @@ class TurnstileBeanOverrideTest {
             assertThat(context).hasNotFailed();
             assertThat(context).hasSingleBean(TurnstileValidationService.class);
             assertThat(context).hasBean("turnstileValidationService");
+        });
+    }
+
+    @Configuration
+    static class CustomRestClientConfiguration {
+        static final RestClient INSTANCE = RestClient.builder().build();
+
+        @Bean(name = "turnstileRestClient")
+        RestClient turnstileRestClient() {
+            return INSTANCE;
+        }
+    }
+
+    @Test
+    void consumerRestClientBeanNamedTurnstileRestClientReplacesDefault() {
+        contextRunner.withUserConfiguration(CustomRestClientConfiguration.class).run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(context.getBean("turnstileRestClient")).isSameAs(CustomRestClientConfiguration.INSTANCE);
+        });
+    }
+
+    @Configuration
+    static class DifferentlyNamedRestClientConfiguration {
+        @Bean
+        RestClient someOtherRestClient() {
+            return RestClient.builder().build();
+        }
+    }
+
+    @Test
+    void consumerRestClientBeanWithDifferentNameDoesNotReplaceDefault() {
+        contextRunner.withUserConfiguration(DifferentlyNamedRestClientConfiguration.class).run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(context).hasBean("turnstileRestClient");
+            assertThat(context).hasBean("someOtherRestClient");
+            assertThat(context).hasSingleBean(TurnstileValidationService.class);
         });
     }
 }

--- a/src/test/java/com/digitalsanctuary/cf/test/turnstile/TurnstileBeanOverrideTest.java
+++ b/src/test/java/com/digitalsanctuary/cf/test/turnstile/TurnstileBeanOverrideTest.java
@@ -1,0 +1,49 @@
+package com.digitalsanctuary.cf.test.turnstile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.digitalsanctuary.cf.turnstile.TurnstileConfiguration;
+import com.digitalsanctuary.cf.turnstile.service.TurnstileValidationService;
+
+/**
+ * Verifies that a consumer-supplied TurnstileValidationService bean replaces the library's
+ * default instead of causing a bean-definition conflict (issue #106).
+ */
+class TurnstileBeanOverrideTest {
+
+    private final WebApplicationContextRunner contextRunner =
+            new WebApplicationContextRunner().withConfiguration(AutoConfigurations.of(TurnstileConfiguration.class));
+
+    @Configuration
+    static class CustomServiceConfiguration {
+        @Bean
+        TurnstileValidationService customTurnstileValidationService() {
+            return Mockito.mock(TurnstileValidationService.class);
+        }
+    }
+
+    @Test
+    void consumerServiceBeanReplacesDefault() {
+        contextRunner.withUserConfiguration(CustomServiceConfiguration.class).run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(context).hasSingleBean(TurnstileValidationService.class);
+            assertThat(context).hasBean("customTurnstileValidationService");
+        });
+    }
+
+    @Test
+    void defaultServiceBeanRegistersWhenNoOverride() {
+        contextRunner.run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(context).hasSingleBean(TurnstileValidationService.class);
+            assertThat(context).hasBean("turnstileValidationService");
+        });
+    }
+}

--- a/src/test/java/com/digitalsanctuary/cf/test/turnstile/TurnstileHealthIndicatorTest.java
+++ b/src/test/java/com/digitalsanctuary/cf/test/turnstile/TurnstileHealthIndicatorTest.java
@@ -60,12 +60,15 @@ class TurnstileHealthIndicatorTest {
     }
 
     @Test
-    void reportsDownWithoutTestCredentialDetailWhenSecretIsMissing() {
+    void reportsDownWithReasonOnlyWhenSecretIsMissing() {
         properties.setSecret("  ");
 
         Health health = healthIndicator.health();
 
+        // The missing-secret check returns before the detail chain is built, so the result carries the reason and nothing else -
+        // in particular no usingTestCredentials detail.
         assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+        assertThat(health.getDetails()).containsOnlyKeys("reason");
         assertThat(health.getDetails()).containsEntry("reason", "Turnstile secret key is not configured");
     }
 

--- a/src/test/java/com/digitalsanctuary/cf/test/turnstile/TurnstileHealthIndicatorTest.java
+++ b/src/test/java/com/digitalsanctuary/cf/test/turnstile/TurnstileHealthIndicatorTest.java
@@ -1,0 +1,82 @@
+package com.digitalsanctuary.cf.test.turnstile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.Status;
+
+import com.digitalsanctuary.cf.turnstile.config.TurnstileConfigProperties;
+import com.digitalsanctuary.cf.turnstile.config.TurnstileHealthIndicator;
+import com.digitalsanctuary.cf.turnstile.service.TurnstileValidationService;
+
+/**
+ * Unit tests for {@link TurnstileHealthIndicator}, including the {@code usingTestCredentials} detail
+ * that surfaces Cloudflare test-credential usage through the actuator health endpoint (issue #106).
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TurnstileHealthIndicatorTest {
+
+    @Mock
+    private TurnstileValidationService validationService;
+
+    private TurnstileConfigProperties properties;
+    private TurnstileHealthIndicator healthIndicator;
+
+    @BeforeEach
+    void setUp() {
+        properties = new TurnstileConfigProperties();
+        properties.setSecret("0x4AAAAAAARealLookingSecretValue");
+        properties.setUrl("https://challenges.cloudflare.com/turnstile/v0/siteverify");
+        healthIndicator = new TurnstileHealthIndicator(validationService, properties);
+    }
+
+    @Test
+    void reportsUsingTestCredentialsTrueWhenServiceDetectsTestCredentials() {
+        when(validationService.isUsingTestCredentials()).thenReturn(true);
+
+        Health health = healthIndicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.UP);
+        assertThat(health.getDetails()).containsEntry("usingTestCredentials", true);
+    }
+
+    @Test
+    void reportsUsingTestCredentialsFalseWhenServiceDetectsRealCredentials() {
+        when(validationService.isUsingTestCredentials()).thenReturn(false);
+
+        Health health = healthIndicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.UP);
+        assertThat(health.getDetails()).containsEntry("usingTestCredentials", false);
+    }
+
+    @Test
+    void reportsDownWithoutTestCredentialDetailWhenSecretIsMissing() {
+        properties.setSecret("  ");
+
+        Health health = healthIndicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+        assertThat(health.getDetails()).containsEntry("reason", "Turnstile secret key is not configured");
+    }
+
+    @Test
+    void reportsDownWhenErrorRateExceedsThreshold() {
+        when(validationService.getErrorRate()).thenReturn(50.0);
+        when(validationService.isUsingTestCredentials()).thenReturn(false);
+
+        Health health = healthIndicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+        assertThat(health.getDetails()).containsEntry("usingTestCredentials", false);
+    }
+}

--- a/src/test/java/com/digitalsanctuary/cf/test/turnstile/TurnstileStartupReporterTest.java
+++ b/src/test/java/com/digitalsanctuary/cf/test/turnstile/TurnstileStartupReporterTest.java
@@ -67,7 +67,7 @@ class TurnstileStartupReporterTest {
     }
 
     private List<String> messagesAt(Level level) {
-        return appender.list.stream().filter(event -> event.getLevel() == level).map(ILoggingEvent::getFormattedMessage).toList();
+        return appender.list.stream().filter(event -> level.equals(event.getLevel())).map(ILoggingEvent::getFormattedMessage).toList();
     }
 
     @Test

--- a/src/test/java/com/digitalsanctuary/cf/test/turnstile/TurnstileStartupReporterTest.java
+++ b/src/test/java/com/digitalsanctuary/cf/test/turnstile/TurnstileStartupReporterTest.java
@@ -1,0 +1,141 @@
+package com.digitalsanctuary.cf.test.turnstile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+
+import com.digitalsanctuary.cf.turnstile.config.TurnstileConfigProperties;
+import com.digitalsanctuary.cf.turnstile.config.TurnstileStartupReporter;
+import com.digitalsanctuary.cf.turnstile.filter.TurnstileCaptchaFilter;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+
+/**
+ * Verifies the startup reporting behaviour of {@link TurnstileStartupReporter}: the Cloudflare
+ * test-credential WARN banner fires only for test credentials, and the login filter registration
+ * state is always reported at INFO (issue #106).
+ */
+class TurnstileStartupReporterTest {
+
+    private static final String CLOUDFLARE_TEST_SITEKEY = "1x00000000000000000000AA";
+    private static final String CLOUDFLARE_TEST_SECRET = "1x0000000000000000000000000000000AA";
+
+    private Logger reporterLogger;
+    private Level originalLevel;
+    private ListAppender<ILoggingEvent> appender;
+
+    @BeforeEach
+    void attachAppender() {
+        reporterLogger = (Logger) LoggerFactory.getLogger(TurnstileStartupReporter.class);
+        originalLevel = reporterLogger.getLevel();
+        appender = new ListAppender<>();
+        appender.start();
+        reporterLogger.addAppender(appender);
+        reporterLogger.setLevel(Level.INFO);
+    }
+
+    @AfterEach
+    void detachAppender() {
+        reporterLogger.setLevel(originalLevel);
+        reporterLogger.detachAppender(appender);
+        appender.stop();
+    }
+
+    private TurnstileConfigProperties properties(String sitekey, String secret) {
+        TurnstileConfigProperties properties = new TurnstileConfigProperties();
+        properties.setSitekey(sitekey);
+        properties.setSecret(secret);
+        properties.setUrl("https://challenges.cloudflare.com/turnstile/v0/siteverify");
+        return properties;
+    }
+
+    @SuppressWarnings("unchecked")
+    private ObjectProvider<TurnstileCaptchaFilter> filterProvider(TurnstileCaptchaFilter filter) {
+        ObjectProvider<TurnstileCaptchaFilter> provider = Mockito.mock(ObjectProvider.class);
+        Mockito.when(provider.getIfAvailable()).thenReturn(filter);
+        return provider;
+    }
+
+    private List<String> messagesAt(Level level) {
+        return appender.list.stream().filter(event -> event.getLevel() == level).map(ILoggingEvent::getFormattedMessage).toList();
+    }
+
+    @Test
+    void warnsWhenConfiguredWithCloudflareTestSitekey() {
+        new TurnstileStartupReporter(properties(CLOUDFLARE_TEST_SITEKEY, "a-real-looking-secret-value"), filterProvider(null))
+                .reportStartupState();
+
+        assertThat(messagesAt(Level.WARN)).anyMatch(message -> message.contains("TEST credentials"));
+    }
+
+    @Test
+    void warnsWhenConfiguredWithCloudflareTestSecret() {
+        new TurnstileStartupReporter(properties("0x4AAAAAAARealLookingSitekey", CLOUDFLARE_TEST_SECRET), filterProvider(null))
+                .reportStartupState();
+
+        assertThat(messagesAt(Level.WARN)).anyMatch(message -> message.contains("TEST credentials"));
+    }
+
+    @Test
+    void doesNotWarnWhenConfiguredWithRealLookingCredentials() {
+        new TurnstileStartupReporter(properties("0x4AAAAAAARealLookingSitekey", "0x4AAAAAAARealLookingSecretValue"), filterProvider(null))
+                .reportStartupState();
+
+        assertThat(messagesAt(Level.WARN)).noneMatch(message -> message.contains("TEST credentials"));
+    }
+
+    @Test
+    void bannerDescribesBothAlwaysPassAndAlwaysFailBehaviour() {
+        new TurnstileStartupReporter(properties(CLOUDFLARE_TEST_SITEKEY, CLOUDFLARE_TEST_SECRET), filterProvider(null)).reportStartupState();
+
+        String banner = String.join("\n", messagesAt(Level.WARN));
+        assertThat(banner).contains("always pass").contains("always fail");
+    }
+
+    @Test
+    void reportsFilterDisabledWhenFilterBeanIsAbsent() {
+        new TurnstileStartupReporter(properties("0x4AAAAAAARealLookingSitekey", "0x4AAAAAAARealLookingSecretValue"), filterProvider(null))
+                .reportStartupState();
+
+        assertThat(messagesAt(Level.INFO))
+                .anyMatch(message -> message.contains("ds.cf.turnstile.login.enabled") && message.contains("DISABLED"));
+    }
+
+    @Test
+    void reportsFilterEnabledWhenFilterBeanIsPresent() {
+        TurnstileCaptchaFilter filter = Mockito.mock(TurnstileCaptchaFilter.class);
+
+        new TurnstileStartupReporter(properties("0x4AAAAAAARealLookingSitekey", "0x4AAAAAAARealLookingSecretValue"), filterProvider(filter))
+                .reportStartupState();
+
+        assertThat(messagesAt(Level.INFO))
+                .anyMatch(message -> message.contains("ds.cf.turnstile.login.enabled") && message.contains("ENABLED"));
+    }
+
+    @Test
+    void logsErrorWhenSecretIsMissing() {
+        new TurnstileStartupReporter(properties("0x4AAAAAAARealLookingSitekey", "  "), filterProvider(null)).reportStartupState();
+
+        assertThat(messagesAt(Level.ERROR)).anyMatch(message -> message.contains("secret key is not configured"));
+    }
+
+    @Test
+    void logsErrorWhenUrlIsMissing() {
+        TurnstileConfigProperties properties = properties("0x4AAAAAAARealLookingSitekey", "0x4AAAAAAARealLookingSecretValue");
+        properties.setUrl(null);
+
+        new TurnstileStartupReporter(properties, filterProvider(null)).reportStartupState();
+
+        assertThat(messagesAt(Level.ERROR)).anyMatch(message -> message.contains("URL is not configured"));
+    }
+}

--- a/src/test/java/com/digitalsanctuary/cf/test/turnstile/TurnstileValidationServiceTest.java
+++ b/src/test/java/com/digitalsanctuary/cf/test/turnstile/TurnstileValidationServiceTest.java
@@ -3,13 +3,16 @@ package com.digitalsanctuary.cf.test.turnstile;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import com.digitalsanctuary.cf.test.TestApplication;
+import com.digitalsanctuary.cf.turnstile.config.TurnstileConfigProperties;
 import com.digitalsanctuary.cf.turnstile.dto.ValidationResult;
 import com.digitalsanctuary.cf.turnstile.dto.ValidationResult.ValidationResultType;
+import com.digitalsanctuary.cf.turnstile.metrics.NoOpTurnstileMetrics;
 import com.digitalsanctuary.cf.turnstile.service.TurnstileValidationService;
 import lombok.extern.slf4j.Slf4j;
 
@@ -159,5 +162,67 @@ public class TurnstileValidationServiceTest {
 
         assertTrue(booleanResult);
         assertTrue(detailedResult.isSuccess());
+    }
+
+    /**
+     * Builds a standalone TurnstileValidationService backed by a fresh TurnstileConfigProperties instance with the given sitekey and secret. Used
+     * to test {@code isUsingTestCredentials()} without mutating the shared autowired service/properties.
+     */
+    private TurnstileValidationService buildServiceWithCredentials(String sitekey, String secret) {
+        TurnstileConfigProperties testProperties = new TurnstileConfigProperties();
+        testProperties.setSitekey(sitekey);
+        testProperties.setSecret(secret);
+        return new TurnstileValidationService(null, testProperties, new NoOpTurnstileMetrics());
+    }
+
+    /**
+     * Verifies that every documented Cloudflare test sitekey is detected as a test credential.
+     *
+     * @see <a href="https://developers.cloudflare.com/turnstile/troubleshooting/testing/">Cloudflare Turnstile testing docs</a>
+     */
+    @Test
+    void isUsingTestCredentialsTrueForCloudflareTestSitekeys() {
+        List<String> cloudflareTestSitekeys = List.of("1x00000000000000000000AA", "2x00000000000000000000AB", "1x00000000000000000000BB",
+                "2x00000000000000000000BB", "3x00000000000000000000FF");
+
+        for (String testSitekey : cloudflareTestSitekeys) {
+            TurnstileValidationService service = buildServiceWithCredentials(testSitekey, "0x4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+            assertTrue(service.isUsingTestCredentials(), "Expected sitekey '" + testSitekey + "' to be detected as a Cloudflare test credential");
+        }
+    }
+
+    /**
+     * Verifies that every documented Cloudflare test secret is detected as a test credential.
+     *
+     * @see <a href="https://developers.cloudflare.com/turnstile/troubleshooting/testing/">Cloudflare Turnstile testing docs</a>
+     */
+    @Test
+    void isUsingTestCredentialsTrueForCloudflareTestSecrets() {
+        List<String> cloudflareTestSecrets = List.of("1x0000000000000000000000000000000AA", "2x0000000000000000000000000000000AA",
+                "3x0000000000000000000000000000000AA");
+
+        for (String testSecret : cloudflareTestSecrets) {
+            TurnstileValidationService service = buildServiceWithCredentials("0x4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", testSecret);
+            assertTrue(service.isUsingTestCredentials(), "Expected secret '" + testSecret + "' to be detected as a Cloudflare test credential");
+        }
+    }
+
+    /**
+     * Verifies that real-looking (non-test) credentials are not flagged as test credentials.
+     */
+    @Test
+    void isUsingTestCredentialsFalseForRealCredentials() {
+        TurnstileValidationService service =
+                buildServiceWithCredentials("0x4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", "0x4BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB");
+        assertFalse(service.isUsingTestCredentials());
+    }
+
+    /**
+     * Verifies that a null (unconfigured) sitekey and secret are not flagged as test credentials.
+     */
+    @Test
+    void isUsingTestCredentialsFalseWhenUnconfigured() {
+        TurnstileValidationService service = buildServiceWithCredentials(null, null);
+        assertFalse(service.isUsingTestCredentials());
     }
 }

--- a/src/test/java/com/digitalsanctuary/cf/test/turnstile/filter/TurnstileCaptchaFilterOptInTest.java
+++ b/src/test/java/com/digitalsanctuary/cf/test/turnstile/filter/TurnstileCaptchaFilterOptInTest.java
@@ -1,0 +1,36 @@
+package com.digitalsanctuary.cf.test.turnstile.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+
+import com.digitalsanctuary.cf.turnstile.TurnstileConfiguration;
+import com.digitalsanctuary.cf.turnstile.filter.TurnstileCaptchaFilter;
+
+/**
+ * Verifies that the login captcha filter registers only when explicitly enabled via
+ * {@code ds.cf.turnstile.login.enabled=true} (issue #106).
+ */
+class TurnstileCaptchaFilterOptInTest {
+
+    private final WebApplicationContextRunner contextRunner =
+            new WebApplicationContextRunner().withConfiguration(AutoConfigurations.of(TurnstileConfiguration.class));
+
+    @Test
+    void filterIsNotRegisteredByDefault() {
+        contextRunner.run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(context).doesNotHaveBean(TurnstileCaptchaFilter.class);
+        });
+    }
+
+    @Test
+    void filterIsRegisteredWhenLoginEnabled() {
+        contextRunner.withPropertyValues("ds.cf.turnstile.login.enabled=true").run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(context).hasSingleBean(TurnstileCaptchaFilter.class);
+        });
+    }
+}

--- a/src/test/java/com/digitalsanctuary/cf/test/turnstile/filter/TurnstileCaptchaFilterOptInTest.java
+++ b/src/test/java/com/digitalsanctuary/cf/test/turnstile/filter/TurnstileCaptchaFilterOptInTest.java
@@ -4,19 +4,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAutoConfiguration;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 
 import com.digitalsanctuary.cf.turnstile.TurnstileConfiguration;
+import com.digitalsanctuary.cf.turnstile.config.TurnstileConfigProperties;
 import com.digitalsanctuary.cf.turnstile.filter.TurnstileCaptchaFilter;
 
 /**
  * Verifies that the login captcha filter registers only when explicitly enabled via
- * {@code ds.cf.turnstile.login.enabled=true} (issue #106).
+ * {@code ds.cf.turnstile.login.enabled=true}, and that its configuration binds from both kebab-case
+ * and camelCase property names (issue #106).
  */
 class TurnstileCaptchaFilterOptInTest {
 
-    private final WebApplicationContextRunner contextRunner =
-            new WebApplicationContextRunner().withConfiguration(AutoConfigurations.of(TurnstileConfiguration.class));
+    private final WebApplicationContextRunner contextRunner = new WebApplicationContextRunner().withConfiguration(
+            AutoConfigurations.of(ConfigurationPropertiesAutoConfiguration.class, TurnstileConfiguration.class));
 
     @Test
     void filterIsNotRegisteredByDefault() {
@@ -32,5 +35,48 @@ class TurnstileCaptchaFilterOptInTest {
             assertThat(context).hasNotFailed();
             assertThat(context).hasSingleBean(TurnstileCaptchaFilter.class);
         });
+    }
+
+    @Test
+    void filterConfigurationDefaultsApplyWhenUnset() {
+        contextRunner.withPropertyValues("ds.cf.turnstile.login.enabled=true").run(context -> {
+            assertThat(context).hasNotFailed();
+            TurnstileConfigProperties properties = context.getBean(TurnstileConfigProperties.class);
+            assertThat(properties.getLogin().getSubmissionPath()).isEqualTo("/login");
+            assertThat(properties.getLogin().getRedirectUrl()).isEqualTo("/login?error=captcha");
+            assertThat(properties.getToken().getParameterName()).isEqualTo("cf-turnstile-response");
+        });
+    }
+
+    @Test
+    void filterConfigurationBindsFromKebabCaseProperties() {
+        contextRunner
+                .withPropertyValues("ds.cf.turnstile.login.enabled=true", "ds.cf.turnstile.login.submission-path=/custom-login",
+                        "ds.cf.turnstile.login.redirect-url=/custom-login?error=captcha",
+                        "ds.cf.turnstile.token.parameter-name=custom-token")
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context).hasSingleBean(TurnstileCaptchaFilter.class);
+                    TurnstileConfigProperties properties = context.getBean(TurnstileConfigProperties.class);
+                    assertThat(properties.getLogin().getSubmissionPath()).isEqualTo("/custom-login");
+                    assertThat(properties.getLogin().getRedirectUrl()).isEqualTo("/custom-login?error=captcha");
+                    assertThat(properties.getToken().getParameterName()).isEqualTo("custom-token");
+                });
+    }
+
+    @Test
+    void filterConfigurationBindsFromCamelCaseProperties() {
+        contextRunner
+                .withPropertyValues("ds.cf.turnstile.login.enabled=true", "ds.cf.turnstile.login.submissionPath=/camel-login",
+                        "ds.cf.turnstile.login.redirectUrl=/camel-login?error=captcha",
+                        "ds.cf.turnstile.token.parameterName=camelToken")
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context).hasSingleBean(TurnstileCaptchaFilter.class);
+                    TurnstileConfigProperties properties = context.getBean(TurnstileConfigProperties.class);
+                    assertThat(properties.getLogin().getSubmissionPath()).isEqualTo("/camel-login");
+                    assertThat(properties.getLogin().getRedirectUrl()).isEqualTo("/camel-login?error=captcha");
+                    assertThat(properties.getToken().getParameterName()).isEqualTo("camelToken");
+                });
     }
 }

--- a/src/test/java/com/digitalsanctuary/cf/test/turnstile/filter/TurnstileCaptchaFilterTest.java
+++ b/src/test/java/com/digitalsanctuary/cf/test/turnstile/filter/TurnstileCaptchaFilterTest.java
@@ -29,7 +29,7 @@ import lombok.extern.slf4j.Slf4j;
  * </p>
  */
 @Slf4j
-@SpringBootTest(classes = TestApplication.class)
+@SpringBootTest(classes = TestApplication.class, properties = "ds.cf.turnstile.login.enabled=true")
 @ActiveProfiles("test")
 public class TurnstileCaptchaFilterTest {
 


### PR DESCRIPTION
Implements #106 for the 2.1.0 release. Closes #106.

## Changes

1. **`TurnstileCaptchaFilter` is now opt-in** — registers only when `ds.cf.turnstile.login.enabled=true` (new property, default `false`, with config metadata). This is the release's one intentional behavior change: previously the filter auto-registered whenever the jar was on the classpath, intercepting POSTs to `/login`. Apps that inject the filter directly (per the old README pattern) will fail startup with `NoSuchBeanDefinitionException` until the property is set — called out in the release notes.
2. **`TurnstileValidationService.isUsingTestCredentials()`** — returns true when the configured sitekey or secret is one of Cloudflare's published test credentials, plus a WARN banner in `onStartup()` so always-pass test keys can't reach production unnoticed. All 8 documented test keys individually covered by tests.
3. **Overridable beans** — `@ConditionalOnMissingBean(TurnstileValidationService.class)` (type-based) on the service; `@ConditionalOnMissingBean(name = "turnstileRestClient")` (deliberately name-based — a type-based condition would back off on any unrelated consumer `RestClient` bean). Both behaviors pinned by context tests, including the regression case where an unrelated `RestClient` bean must NOT suppress the library's client.
4. **Docs** — README updates (opt-in filter, test-credential detection, version references bumped to 2.1.0 ahead of the release since the release process doesn't touch the README) and `docs/RELEASE-NOTES-2.1.0.md` with the upgrade callout.

No changes to the validation API: `validateTurnstileResponse(...)`, `validateTurnstileResponseDetailed(...)`, `getClientIpAddress(...)`, and `getTurnstileSitekey()` are untouched. Downstream, SpringUserFramework #346 compiles against `isUsingTestCredentials()` — the signature is a contract.

## Deliberately not included

A master `ds.cf.turnstile.enabled` switch (issue #106 listed it as "worth considering"): skipped as YAGNI for this release — downstream doesn't need it and `spring.autoconfigure.exclude` remains available.

## Verification

`./gradlew build` green (32 tests passing, JDK 17 and 21 test tasks). Work was implemented task-by-task with per-task spec/quality reviews and a final whole-branch review; the final review's one Important finding (RestClient override behavior untested) was fixed and re-reviewed.

After merge, release with:
```
./gradlew release -Prelease.useAutomaticVersion=true -Prelease.releaseVersion=2.1.0 -Prelease.newVersion=2.1.1-SNAPSHOT
```


## Second review wave (external findings)

A follow-up review pass produced verified findings, all applied:

- **Startup checks relocated** to a new unconditional `TurnstileStartupReporter` bean — the missing-secret/URL errors and the test-credential banner previously lived on `TurnstileValidationService`, which this PR made overridable, so overrides could silently lose them. The reporter also logs the login filter's registration state (ENABLED/DISABLED) at startup, covering the silent upgrade path for apps that relied on servlet-container auto-registration.
- **Banner wording corrected**: Cloudflare's `2x`/`3x` test keys always *fail* (locking out all users), so the banner now says "always pass (NO bot protection) or always fail (ALL users blocked)" instead of only "provides NO protection". The WARN is now covered by tests in both directions (issue #106 acceptance criterion 3).
- **Filter properties migrated off `@Value` onto `TurnstileConfigProperties`** (`login.submission-path`, `login.redirect-url`, `token.parameter-name`): the config metadata has always advertised kebab-case keys, but `@Value` placeholders do exact-key lookup, so kebab-case settings were silently dead (and shadowed by the library's own defaults). Relaxed binding now makes both kebab-case and the old camelCase forms work — both pinned by tests. Defaults moved to field initializers; `config/turnstile.properties` camelCase entries removed.
- **Health indicator** now exposes a `usingTestCredentials` detail, so the machine-readable health surface no longer reads maximally healthy while running on always-pass keys.
- Context-runner tests now include `ConfigurationPropertiesAutoConfiguration` (binding was previously a no-op in those tests), plus a real-subclass override test and a pin that the startup reporter stays unconditional under consumer overrides.
- README/release-notes accuracy fixes (filter example shows `enabled: true`, bean-not-created mechanism wording, tempered health/metrics override claim).

50 tests green on JDK 17 and 21.
